### PR TITLE
feat: specify time zone for attributes

### DIFF
--- a/source/includes/receivables/criar.md
+++ b/source/includes/receivables/criar.md
@@ -21,7 +21,7 @@ curl --location --request POST 'https://recebiveis.fintera.com.br/api/v1/receiva
     "payment_method": "credit_card",
     "acquirer_slug": "redecard",
     "card_brand": "mastercard",
-    "payment_processed_at": "2023-03-16T13:59:59",
+    "payment_processed_at": "2023-03-16T13:59:59.000-03:00",
     "installments_count": 1,
     "nsu": "1234567890",
     "authorization_code": "987654",
@@ -93,7 +93,7 @@ gross_value | Sim | O valor bruto do recebível, sem descontos ou taxas.
 payment_method | Sim | A forma de pagamento (opções aceitas: _credit_card_, _debit_card_, _boleto_, _bank_transfer_, _pix_, _cash_, _bank_check_, _others_).
 acquirer_slug | Sim (caso payment_method é _credit_card_ ou _debit_card_)| O identificador da adquirente (opções aceitas: _redecard_, _cielo_, _getnet_, _stone_, _sipag_)
 card_brand | Sim (caso payment_method é _credit_card_ ou _debit_card_)| A bandeira do cartão de crédito utilizado (opções aceitas: _agiplan_, _amex_, _aura_, _banescard_, _banrisul_, _cabal_, _convenio_loja_, _credsystem_, _credz_, _diners_, _elo_, _hipercard_, _jcb_, _maestro_, _mastercard_, _outros_, _redecard_, _redeshop_, _sorocred_, _valecard_, _visa_, _visa_electron_)
-payment_processed_at | Sim | A data e hora em que o pagamento foi processado.
+payment_processed_at | Sim | A data e hora em que o pagamento foi processado, com fuso de Brasília.
 installments_count | Sim | O número total de parcelas.
 nsu | Sim (caso payment_method é _credit_card_ ou _debit_card_) | Número sequencial único da transação, utilizado para identificar a transação junto à adquirente.
 authorization_code | Sim (caso payment_method é _credit_card_ ou _debit_card_) | O código de autorização da transação.


### PR DESCRIPTION
Specify time zone for `payment_processed_at` to avoid mistakes.